### PR TITLE
[bug/1687] Rely on file existence to decide manifest path to use

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,6 +3,3 @@ require "colorize"
 
 ENV["CRYSTAL_ENV"] = "TEST"
 
-# This forces use of cluster-tools manifest in the repo's tools dir when running specs.
-ENV["USE_MANIFEST_SPECS_DIRECTORY"] = "yes"
-

--- a/src/utils/embedded_file_manager.cr
+++ b/src/utils/embedded_file_manager.cr
@@ -1,5 +1,9 @@
 module EmbeddedFileManager
   macro cluster_tools
-    CLUSTER_TOOLS = ENV["USE_MANIFEST_SPECS_DIRECTORY"]? ? File.read("./tools/cluster-tools/manifest.yml") : File.read("./lib/cluster_tools/tools/cluster-tools/manifest.yml")
+    CLUSTER_TOOLS = if ENV["USE_MANIFEST_SPECS_DIRECTORY"]?
+        File.read("./tools/cluster-tools/manifest.yml")
+      else
+        File.read("./lib/cluster_tools/tools/cluster-tools/manifest.yml")
+      end
   end
 end

--- a/src/utils/embedded_file_manager.cr
+++ b/src/utils/embedded_file_manager.cr
@@ -1,9 +1,13 @@
 module EmbeddedFileManager
   macro cluster_tools
-    CLUSTER_TOOLS = if ENV["USE_MANIFEST_SPECS_DIRECTORY"]?
-        File.read("./tools/cluster-tools/manifest.yml")
-      else
+
+    # When being used as a shard, the manifest directory is available within the shard in the lib directory.
+    # When running `crystal spec` within project, refer to tools in repo root.
+    CLUSTER_TOOLS = if File.exists?("./lib/cluster_tools/tools/cluster-tools/manifest.yml")
         File.read("./lib/cluster_tools/tools/cluster-tools/manifest.yml")
+      else
+        File.read("./tools/cluster-tools/manifest.yml")
       end
+
   end
 end


### PR DESCRIPTION
This PR removes the use of env var to set manifest path for cluster-tools.

The new implementation relies on file existence to decide manifest path to use.