### PR TITLE
[cncf/cnf-testsuite#1751] Depend on kubectl_client and docker_client dependencies to ~> 1.0.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,11 +2,11 @@ version: 2.0
 shards:
   docker_client:
     git: https://github.com/cnf-testsuite/docker_client.git
-    version: 0.1.0+git.commit.32dacefbc3dfcf98c8126ff793c97a3038e9b122
+    version: 1.0.0
 
   kubectl_client:
     git: https://github.com/cnf-testsuite/kubectl_client.git
-    version: 0.1.0+git.commit.12cad24a372469e34e0f64019b10e1b3dc82a124
+    version: 1.0.1
 
   popcorn:
     git: https://github.com/icyleaf/popcorn.git

--- a/shard.yml
+++ b/shard.yml
@@ -18,6 +18,6 @@ dependencies:
     version: '~> 1.0.0'
   docker_client:
     github: cnf-testsuite/docker_client
-    branch: main
+    version: '~> 1.0.0'
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: cluster_tools
-version: 0.1.1
+version: 1.0.0
 
 authors:
   - William Harris <wharris@upscalews.com>

--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ crystal: '>= 1.0.0'
 dependencies:
   kubectl_client:
     github: cnf-testsuite/kubectl_client
-    branch: '>= 1.0.0'
+    branch: '~> 1.0.0'
   docker_client:
     github: cnf-testsuite/docker_client
     branch: main

--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ crystal: '>= 1.0.0'
 dependencies:
   kubectl_client:
     github: cnf-testsuite/kubectl_client
-    branch: main
+    branch: '>= 1.0.0'
   docker_client:
     github: cnf-testsuite/docker_client
     branch: main

--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ crystal: '>= 1.0.0'
 dependencies:
   kubectl_client:
     github: cnf-testsuite/kubectl_client
-    branch: '~> 1.0.0'
+    version: '~> 1.0.0'
   docker_client:
     github: cnf-testsuite/docker_client
     branch: main


### PR DESCRIPTION
The following changes are to help cncf/cnf-testsuite#1751.

* Update kubectl_client dependency to ~> 1.0.0.
* Update docker_client dependency to ~> 1.0.0.