### PR TITLE
Increase the timeout for cluster-tools installation

### DIFF
--- a/cluster_tools.cr
+++ b/cluster_tools.cr
@@ -233,7 +233,7 @@ module ClusterTools
 
   def self.wait_for_cluster_tools
     Log.info { "ClusterTools wait_for_cluster_tools" }
-    KubectlClient::Get.resource_wait_for_install("Daemonset", "cluster-tools", namespace: self.namespace!)
+    KubectlClient::Get.resource_wait_for_install("Daemonset", "cluster-tools", namespace: self.namespace!, wait_count: 300)
     # KubectlClient::Get.resource_wait_for_install("Daemonset", "cluster-tools-k8s", namespace: self.namespace)
   end
 


### PR DESCRIPTION
Since cluster-tools images are usually large,
their installation typically takes more time than the default value of 180 seconds. This change increases the timeout to 300 seconds.
This change was discussed in https://github.com/cnti-testcatalog/testsuite/issues/1975