### PR TITLE
Feat: Add option to filter processes by both containers and nodes

### DIFF
--- a/cluster_tools.cr
+++ b/cluster_tools.cr
@@ -163,7 +163,7 @@ module ClusterTools
     pid 
   end
   #each_container_by_resource(resource, namespace) do | container_id, container_pid_on_node, node, container_proctree_statuses, container_status|
-  def self.all_containers_by_resource?(resource, namespace, &block) 
+  def self.all_containers_by_resource?(resource, namespace, only_container_pids : Bool = false, &block) 
 		kind = resource["kind"].downcase
 		case kind
 		when  "deployment","statefulset","pod","replicaset", "daemonset"
@@ -210,8 +210,12 @@ module ClusterTools
 
 						node_name = node.dig("metadata", "name").as_s
 						Log.info { "node name : #{node_name}" }
-						pids = KernelIntrospection::K8s::Node.pids(node)
-						Log.info { "proctree_by_pid pids: #{pids}" }
+						pids = if only_container_pids 
+                                                         KernelIntrospection::K8s::Node.pids_by_container(container_id, node)
+                                                       else
+                                                         KernelIntrospection::K8s::Node.pids(node)
+                                                       end
+						Log.info { "parsed pids: #{pids}" }
 						proc_statuses = KernelIntrospection::K8s::Node.all_statuses_by_pids(pids, node)
 
 						container_proctree_statuses = KernelIntrospection::K8s::Node.proctree_by_pid(container_pid_on_node, node, proc_statuses)

--- a/cluster_tools.cr
+++ b/cluster_tools.cr
@@ -210,11 +210,11 @@ module ClusterTools
 
 						node_name = node.dig("metadata", "name").as_s
 						Log.info { "node name : #{node_name}" }
-						pids = if only_container_pids 
-                                                         KernelIntrospection::K8s::Node.pids_by_container(container_id, node)
-                                                       else
-                                                         KernelIntrospection::K8s::Node.pids(node)
-                                                       end
+						if only_container_pids 
+                                                  pids = KernelIntrospection::K8s::Node.pids_by_container(container_id, node)
+                                                else
+                                                  pids = KernelIntrospection::K8s::Node.pids(node)
+                                                end
 						Log.info { "parsed pids: #{pids}" }
 						proc_statuses = KernelIntrospection::K8s::Node.all_statuses_by_pids(pids, node)
 


### PR DESCRIPTION
**Description**
Allows for the returned container resources to **only** be the container resources. The original solution returned the pid tree constructed with pids from node, thus slowing things down. This functionality needs to remain due to the zombie task expecting such behavior.

**Refs**
[#2110](https://github.com/cnti-testcatalog/testsuite/pull/2110)