### PR TITLE
switch dockerhub organization to lfncnti

### DIFF
--- a/src/templates/manifest-host-pid.yml.ecr
+++ b/src/templates/manifest-host-pid.yml.ecr
@@ -16,7 +16,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: cluster-tools
-          image: conformance/cluster-tools:v1.0.5
+          image: lfncnti/cluster-tools:v1.0.6
           imagePullPolicy: Always
           command: ["/bin/sh"]
           args: ["-c", "sleep infinity"]
@@ -45,35 +45,3 @@ spec:
       - name: systemd
         hostPath:
           path: /run/systemd
-# ---
-# apiVersion: apps/v1
-# kind: DaemonSet
-# metadata:
-#     name: cluster-tools-k8s
-# spec:
-#   selector:
-#     matchLabels:
-#       name: cluster-tools-k8s
-#   template:
-#     metadata:
-#       labels:
-#         name: cluster-tools-k8s
-#     spec:
-#       containers:
-#         - name: cluster-tools-k8s
-#           image: conformance/cluster-tools:v1.0.0
-#           imagePullPolicy: Always
-#           command: ["/bin/sh"]
-#           args: ["-c", "sleep infinity"]
-#           volumeMounts:
-#           - mountPath: /run/containerd/containerd.sock
-#             name: containerd-volume
-#           - mountPath: /run/dockershim.sock
-#             name: dockerd-volume
-#       volumes:
-#       - name: containerd-volume
-#         hostPath:
-#           path: /var/run/containerd/containerd.sock
-#       - name: dockerd-volume
-#         hostPath:
-#           path: /run/dockershim.sock

--- a/src/templates/manifest.yml.ecr
+++ b/src/templates/manifest.yml.ecr
@@ -15,7 +15,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: cluster-tools
-          image: conformance/cluster-tools:v1.0.5
+          image: lfncnti/cluster-tools:v1.0.6
           imagePullPolicy: Always
           command: ["/bin/sh"]
           args: ["-c", "sleep infinity"]
@@ -38,35 +38,3 @@ spec:
       - name: dockerd-volume
         hostPath:
           path: /run/dockershim.sock
-# ---
-# apiVersion: apps/v1
-# kind: DaemonSet
-# metadata:
-#     name: cluster-tools-k8s
-# spec:
-#   selector:
-#     matchLabels:
-#       name: cluster-tools-k8s
-#   template:
-#     metadata:
-#       labels:
-#         name: cluster-tools-k8s
-#     spec:
-#       containers:
-#         - name: cluster-tools-k8s
-#           image: conformance/cluster-tools:v1.0.0
-#           imagePullPolicy: Always
-#           command: ["/bin/sh"]
-#           args: ["-c", "sleep infinity"]
-#           volumeMounts:
-#           - mountPath: /run/containerd/containerd.sock
-#             name: containerd-volume
-#           - mountPath: /run/dockershim.sock
-#             name: dockerd-volume
-#       volumes:
-#       - name: containerd-volume
-#         hostPath:
-#           path: /var/run/containerd/containerd.sock
-#       - name: dockerd-volume
-#         hostPath:
-#           path: /run/dockershim.sock


### PR DESCRIPTION
Switch organization to lfncnti and bump
cluster-tools image version to v1.0.6.

Refs: cnti-testcatalog/testsuite#2063