### PR TITLE
Leverage the dockerhub account for skopeo if set

### DIFF
--- a/cluster_tools.cr
+++ b/cluster_tools.cr
@@ -249,7 +249,13 @@ module ClusterTools
   def self.official_content_digest_by_image_name(image_name)
     Log.info { "official_content_digest_by_image_name: #{image_name}"}
 
-    result = exec("skopeo inspect docker://#{image_name}")
+    if ENV["DOCKERHUB_USERNAME"]? && ENV["DOCKERHUB_PASSWORD"]?
+      Log.info { "Use USERNAME and PASSWORD for accessing the registry via skopeo" }
+      result = exec("skopeo inspect --creds #{ENV["DOCKERHUB_USERNAME"]}:#{ENV["DOCKERHUB_PASSWORD"]} docker://#{image_name}")
+    else
+      Log.info { "Access the registry anonymously via skopeo" }
+      result = exec("skopeo inspect docker://#{image_name}")
+    end
     response = result[:output]
     if result[:status].success? && !response.empty?
       return JSON.parse(response)

--- a/cluster_tools.cr
+++ b/cluster_tools.cr
@@ -250,12 +250,13 @@ module ClusterTools
     Log.info { "official_content_digest_by_image_name: #{image_name}"}
 
     if ENV["DOCKERHUB_USERNAME"]? && ENV["DOCKERHUB_PASSWORD"]?
-      Log.info { "Use USERNAME and PASSWORD for accessing the registry via skopeo" }
-      result = exec("skopeo inspect --creds #{ENV["DOCKERHUB_USERNAME"]}:#{ENV["DOCKERHUB_PASSWORD"]} docker://#{image_name}")
+      Log.info { "Using USERNAME and PASSWORD for accessing the registry via skopeo" }
+      registry_creds = "--creds #{ENV["DOCKERHUB_USERNAME"]}:#{ENV["DOCKERHUB_PASSWORD"]}"
     else
       Log.info { "Access the registry anonymously via skopeo" }
-      result = exec("skopeo inspect docker://#{image_name}")
+      registry_creds = ""
     end
+    result = exec("skopeo inspect #{registry_creds} docker://#{image_name}")
     response = result[:output]
     if result[:status].success? && !response.empty?
       return JSON.parse(response)


### PR DESCRIPTION
skopeo directly pulls from docker.io which easily reaches the pull rate limit.

Please see shared_database and observability failing because of skopeo (whatever the use of private mirror or mirror.gcr.io):
- https://github.com/cnti-testcatalog/testsuite/actions/runs/12674901774/job/35470396257?pr=2203
- https://github.com/cnti-testcatalog/testsuite/actions/runs/12674901774/job/35470398665?pr=2203